### PR TITLE
Migrate (most stuff) from setup.py to setup.cfg

### DIFF
--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = chaosinventory
+version = attr: chaosinventory.__version__
+author = Chaosinventory Team
+author_email = devnull+not-setup@chaosinventory.de
+license = AGPL-3.0
+#long_description = file: README.md
+long_description_content_type = text/markdown
+keywords = chaos, inventory, organisation, blåhaj
+url = https://github.com/chaosinventory/
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Environment :: Web Environment
+    Framework :: Django :: 3.1
+    Intended Audience :: Other Audience
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Internet :: WWW/HTTP :: Indexing/Search
+project_urls =
+  Documentation = https://chaosinventory.readthedocs.io/
+  Source = https://github.com/chaosinventory/chaosinventory
+  Tracker = https://github.com/chaosinventory/chaosinventory/issues
+
+[options]
+packages = find:
+install_requires = Django==3.1.*; psycopg2-binary
+python_requires = >=3.5
+
+[options.entry_points]
+console_scripts =
+    chaosinventory = chaosinventory.__main__:main

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,8 +1,5 @@
 from pathlib import Path
-
 from setuptools import find_packages, setup
-
-import chaosinventory
 
 here = Path(__file__).resolve().parent
 
@@ -10,34 +7,5 @@ with open(here.parent / 'README.md') as readme:
     long_description = readme.read()
 
 setup(
-    name='chaosinventory',
-    version=chaosinventory.__version__,
-    python_requires='>=3.5',
-    description = '',
     long_description=long_description,
-    url='https://github.com/chaosinventory/',
-    author='Chaosinventory Team',
-    license='AGPL-3.0',
-    classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Environment :: Web Environment',
-        'Framework :: Django :: 3.1',
-        'Intended Audience :: Other Audience',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Internet :: WWW/HTTP :: Indexing/Search',
-    ],
-    keywords ='chaos inventory organisation blåhaj',
-    install_requires=[
-        'Django==3.1.*',
-        'psycopg2-binary'
-    ],
-    packages=find_packages(),
-    entry_points = {
-        'console_scripts': [
-            'chaosinventory = chaosinventory.__main__:main'
-        ]
-    }
 )


### PR DESCRIPTION
In my oppinion the setup.cfg looks cleaner and is better suited for most
paraneters.