### PR TITLE
Fix CI in multiple instances

### DIFF
--- a/src/chaosinventory/base/admin.py
+++ b/src/chaosinventory/base/admin.py
@@ -1,3 +1,3 @@
-from django.contrib import admin
+from django.contrib import admin  # noqa
 
 # Register your models here.

--- a/src/chaosinventory/base/models.py
+++ b/src/chaosinventory/base/models.py
@@ -1,5 +1,6 @@
-from django.db import models
 from django.core.validators import MinValueValidator
+from django.db import models
+
 
 class CommonModel(models.Model):
     name = models.CharField(
@@ -162,7 +163,7 @@ class Product(CommonModel):
 class Item(CommonModel):
     amount = models.PositiveIntegerField(
         default=1,
-        validators=[ MinValueValidator(1) ],
+        validators=[MinValueValidator(1)],
     )
 
     belongs_to = models.ForeignKey(

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -44,4 +44,7 @@ known_first_party = chaosinventory
 multi_line_output = 5
 line_length = 79
 honor_noqa = true
-skip = bootstrap,chaosinventory/settings.py
+skip =
+  bootstrap
+  chaosinventory/settings.py
+  chaosinventory/base/migrations/

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -50,6 +50,5 @@ multi_line_output = 5
 line_length = 79
 honor_noqa = true
 skip =
-  bootstrap
   chaosinventory/settings.py
   chaosinventory/base/migrations/

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -36,7 +36,12 @@ console_scripts =
 
 [flake8]
 max-line-length = 119
-exclude = migrations,static,build,dist,sdist
+exclude =
+  migrations
+  static
+  build
+  dist
+  sdist
 
 [isort]
 include_trailing_comma = true


### PR DESCRIPTION
- Exclude migrations from isort (ed6aa17)
- Fix flake8 and isort in models and admin.py (4d3f1ac)

Note: Remove noqua from `admin.py` once #19 is merged

Close #29 
