### PR TITLE
Validate item location and parent item

### DIFF
--- a/src/chaosinventory/base/models.py
+++ b/src/chaosinventory/base/models.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
 
@@ -218,6 +219,12 @@ class Item(CommonModel):
         null=True,
         blank=True,
     )
+
+    def clean(self):
+        if (self.target_location and self.target_item):
+            raise ValidationError("Target location and item are mutually exclusive")
+        if (self.actual_location and self.actual_item):
+            raise ValidationError("Actual location and item are mutually exclusive")
 
 
 class InventoryIdSchema(CommonModel):


### PR DESCRIPTION
We have to make sure, that only one is set `actual_location` or `actual_item` (same with `target_*`). I experimented a bit and setteld down with a [model validation method ](https://docs.djangoproject.com/en/3.1/ref/models/instances/#django.db.models.Model.clean).

You can test this by creating an item with both set. There should be a validation error on saving.