### PR TITLE
Introduce a singe endpoint to get item parent

### DIFF
--- a/src/chaosinventory/base/models.py
+++ b/src/chaosinventory/base/models.py
@@ -223,6 +223,19 @@ class Item(CommonModel):
     )
 
     @property
+    def target_parent(self):
+        return self.target_item if self.target_item else self.target_location
+
+    @target_parent.setter
+    def target_parent(self, new_parent):
+        if type(new_parent) is Item:
+            self.target_location = None
+            self.target_item = new_parent
+        else:
+            self.target_item = None
+            self.target_location = new_parent
+
+    @property
     def actual_parent(self):
         return self.actual_item if self.actual_item else self.actual_location
 

--- a/src/chaosinventory/base/models.py
+++ b/src/chaosinventory/base/models.py
@@ -222,6 +222,19 @@ class Item(CommonModel):
         blank=True,
     )
 
+    @property
+    def actual_parent(self):
+        return self.actual_item if self.actual_item else self.actual_location
+
+    @actual_parent.setter
+    def actual_parent(self, new_parent):
+        if type(new_parent) is Item:
+            self.actual_location = None
+            self.actual_item = new_parent
+        else:
+            self.actual_item = None
+            self.actual_location = new_parent
+
     def clean(self):
         if (self.target_location and self.target_item):
             raise ValidationError("Target location and item are mutually exclusive")


### PR DESCRIPTION
Currently we have two endpoints to get an item parent and I want to introduce one API to distinguish between once an for all.

You can test this using `python3 ./manage.py shell`

```
from chaosinventory.base.models import Item, Location
i = Item()
i.name = "i"
j = Item()
j.name = "j"
l = Location()
l.name = "l"
```
Now you can play around with some of these statements
```
i.actual_parent
i.actual_parent = j
i.actual_parent = l
i.actual_location
i.actual_item
```