### PR TITLE
Refactor API serializers

### DIFF
--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -57,6 +57,59 @@ class DataTypeSerializer(serializers.ModelSerializer):
         ]
 
 
+class NestedEntitySerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='entity-detail')
+
+    class Meta:
+        model = Entity
+        fields = [
+            '_url',
+            'id',
+            'name',
+            'note',
+            'part_of_id',
+        ]
+
+
+class EntitySerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='entity-detail')
+
+    part_of = NestedEntitySerializer(
+        read_only=True,
+    )
+    part_of_id = serializers.PrimaryKeyRelatedField(
+        required=False,
+        allow_null=True,
+        source='part_of',
+        queryset=Entity.objects.all(),
+    )
+
+    tags = NestedTagSerializer(
+        required=False,
+        allow_null=True,
+        many=True,
+    )
+    tag_ids = serializers.PrimaryKeyRelatedField(
+        many=True,
+        required=False,
+        source='tags',
+        queryset=Tag.objects.all(),
+    )
+
+    class Meta:
+        model = Entity
+        fields = [
+            '_url',
+            'id',
+            'name',
+            'note',
+            'part_of',
+            'part_of_id',
+            'tags',
+            'tag_ids',
+        ]
+
+
 class InventoryIdSchemaSerializer(serializers.ModelSerializer):
     class Meta:
         model = InventoryIdSchema
@@ -212,59 +265,6 @@ class OverlayItemSerializer(serializers.ModelSerializer):
             'item',
             'target_item',
             'target_location',
-        ]
-
-
-class NestedEntitySerializer(serializers.ModelSerializer):
-    _url = serializers.HyperlinkedIdentityField(view_name='entity-detail')
-
-    class Meta:
-        model = Entity
-        fields = [
-            '_url',
-            'id',
-            'name',
-            'note',
-            'part_of_id',
-        ]
-
-
-class EntitySerializer(serializers.ModelSerializer):
-    _url = serializers.HyperlinkedIdentityField(view_name='entity-detail')
-
-    part_of = NestedEntitySerializer(
-        read_only=True,
-    )
-    part_of_id = serializers.PrimaryKeyRelatedField(
-        required=False,
-        allow_null=True,
-        source='part_of',
-        queryset=Entity.objects.all(),
-    )
-
-    tags = NestedTagSerializer(
-        required=False,
-        allow_null=True,
-        many=True,
-    )
-    tag_ids = serializers.PrimaryKeyRelatedField(
-        many=True,
-        required=False,
-        source='tags',
-        queryset=Tag.objects.all(),
-    )
-
-    class Meta:
-        model = Entity
-        fields = [
-            '_url',
-            'id',
-            'name',
-            'note',
-            'part_of',
-            'part_of_id',
-            'tags',
-            'tag_ids',
         ]
 
 

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -133,6 +133,30 @@ class NestedLocationDataSerializer(serializers.ModelSerializer):
         ]
 
 
+class NestedProductDataSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='productinventoryid-detail')
+
+    type = DataTypeSerializer(
+        read_only=True,
+    )
+    type_id = serializers.PrimaryKeyRelatedField(
+        source='type',
+        queryset=DataType.objects.all(),
+    )
+
+
+    class Meta:
+        model = ProductData
+        fields = [
+            '_url',
+            'id',
+            'value',
+            'type',
+            'type_id',
+            'product_id',
+        ]
+
+
 class InventoryIdSchemaSerializer(serializers.ModelSerializer):
     class Meta:
         model = InventoryIdSchema
@@ -174,17 +198,6 @@ class ItemDataSerializer(serializers.ModelSerializer):
             'value',
             'type',
             'item',
-        ]
-
-
-class ProductDataSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ProductData
-        fields = [
-            'id',
-            'value',
-            'type',
-            'product'
         ]
 
 
@@ -338,7 +351,7 @@ class ProductSerializer(serializers.ModelSerializer):
         queryset=ProductInventoryId.objects.all(),
     )
 
-    productdata_set = ProductDataSerializer(
+    productdata_set = NestedProductDataSerializer(
         read_only=True,
         many=True,
     )
@@ -404,6 +417,38 @@ class ProductInventoryIdSerializer(serializers.ModelSerializer):
             'value',
             'schema',
             'schema_id',
+            'product',
+            'product_id',
+        ]
+
+
+class ProductDataSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='productinventoryid-detail')
+
+    type = DataTypeSerializer(
+        read_only=True,
+    )
+    type_id = serializers.PrimaryKeyRelatedField(
+        source='type',
+        queryset=DataType.objects.all(),
+    )
+
+    product = NestedProductSerializer(
+        read_only=True,
+    )
+    product_id = serializers.PrimaryKeyRelatedField(
+        source='product',
+        queryset=Product.objects.all(),
+    )
+
+    class Meta:
+        model = ProductData
+        fields = [
+            '_url',
+            'id',
+            'value',
+            'type',
+            'type_id',
             'product',
             'product_id',
         ]

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -44,6 +44,19 @@ class TagSerializer(serializers.ModelSerializer):
         ]
 
 
+class DataTypeSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='datatype-detail')
+
+    class Meta:
+        model = DataType
+        fields = [
+            '_url',
+            'id',
+            'name',
+            'note',
+        ]
+
+
 class InventoryIdSchemaSerializer(serializers.ModelSerializer):
     class Meta:
         model = InventoryIdSchema
@@ -74,16 +87,6 @@ class NestedProductInventoryIdSerializer(serializers.ModelSerializer):
             'schema',
             'schema_id',
             'product_id',
-        ]
-
-
-class DataTypeSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = DataType
-        fields = [
-            'id',
-            'name',
-            'note',
         ]
 
 

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -7,6 +7,43 @@ from .models import (
 )
 
 
+class NestedTagSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='tag-detail')
+
+    class Meta:
+        model = Tag
+        fields = [
+            '_url',
+            'id',
+            'name',
+            'parent_id',
+        ]
+
+
+class TagSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='tag-detail')
+
+    parent = NestedTagSerializer(
+        read_only=True,
+    )
+    parent_id = serializers.PrimaryKeyRelatedField(
+        required=False,
+        allow_null=True,
+        source='parent',
+        queryset=Tag.objects.all(),
+    )
+
+    class Meta:
+        model = Tag
+        fields = [
+            '_url',
+            'id',
+            'name',
+            'parent',
+            'parent_id',
+        ]
+
+
 class InventoryIdSchemaSerializer(serializers.ModelSerializer):
     class Meta:
         model = InventoryIdSchema
@@ -37,15 +74,6 @@ class NestedProductInventoryIdSerializer(serializers.ModelSerializer):
             'schema',
             'schema_id',
             'product_id',
-        ]
-
-class TagSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Tag
-        fields = [
-            'id',
-            'name',
-            'parent'
         ]
 
 
@@ -211,8 +239,9 @@ class EntitySerializer(serializers.ModelSerializer):
         queryset=Entity.objects.all(),
     )
 
-    tags = TagSerializer(
-        read_only=True,
+    tags = NestedTagSerializer(
+        required=False,
+        allow_null=True,
         many=True,
     )
     tag_ids = serializers.PrimaryKeyRelatedField(
@@ -285,8 +314,9 @@ class ProductSerializer(serializers.ModelSerializer):
         queryset=ProductData.objects.all(),
     )
 
-    tags = TagSerializer(
-        read_only=True,
+    tags = NestedTagSerializer(
+        required=False,
+        allow_null=True,
         many=True,
     )
     tag_ids = serializers.PrimaryKeyRelatedField(
@@ -447,8 +477,9 @@ class ItemSerializer(serializers.ModelSerializer):
         queryset=ItemData.objects.all(),
     )
 
-    tags = TagSerializer(
-        read_only=True,
+    tags = NestedTagSerializer(
+        required=False,
+        allow_null=True,
         many=True,
     )
     tag_ids = serializers.PrimaryKeyRelatedField(

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -190,6 +190,99 @@ class ProductSerializer(serializers.ModelSerializer):
 
 
 class ItemSerializer(serializers.ModelSerializer):
+    belongs_to = EntitySerializer(
+        read_only=True,
+    )
+    belongs_to_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        required=False,
+        source='belongs_to',
+        queryset=Entity.objects.all(),
+    )
+
+    actual_location = LocationSerializer(
+        read_only=True,
+    )
+    actual_location_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        required=False,
+        source='actual_location',
+        queryset=Location.objects.all(),
+    )
+
+    target_location = LocationSerializer(
+        read_only=True,
+    )
+    target_location_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        required=False,
+        source='target_location',
+        queryset=Location.objects.all(),
+    )
+
+    product = ProductSerializer(
+        read_only=True,
+    )
+    product_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        source='product',
+        queryset=Product.objects.all(),
+    )
+
+    #target_item = ItemSerializer()
+    target_item_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        required=False,
+        allow_null=True,
+        source='target_item',
+        queryset=Item.objects.all(),
+    )
+
+    #actual_item = ItemSerializer()
+    actual_item_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        required=False,
+        allow_null=True,
+        source='actual_item',
+        queryset=Item.objects.all(),
+    )
+
+    iteminventoryid_set = ItemInventoryIdSerializer(
+        read_only=True,
+        many=True,
+    )
+    iteminventoryid_id_set = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        many=True,
+        required=False,
+        source='iteminventoryid_set',
+        queryset=ItemInventoryId.objects.all(),
+    )
+
+    itemdata_set = ItemDataSerializer(
+        read_only=True,
+        many=True,
+    )
+    itemdata_id_set = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        many=True,
+        required=False,
+        source='itemdata_set',
+        queryset=ItemData.objects.all(),
+    )
+
+    tags = TagSerializer(
+        read_only=True,
+        many=True,
+    )
+    tag_ids = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        many=True,
+        required=False,
+        source='tags',
+        queryset=Tag.objects.all(),
+    )
+
     class Meta:
         model = Item
         fields = [
@@ -198,14 +291,23 @@ class ItemSerializer(serializers.ModelSerializer):
             'note',
             'amount',
             'belongs_to',
+            'belongs_to_id',
             'actual_location',
+            'actual_location_id',
             'target_location',
+            'target_location_id',
             'product',
+            'product_id',
             'target_item',
+            'target_item_id',
             'actual_item',
+            'actual_item_id',
             'iteminventoryid_set',
+            'iteminventoryid_id_set',
             'itemdata_set',
+            'itemdata_id_set',
             'tags',
+            'tag_ids',
         ]
 
 

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -85,13 +85,13 @@ class EntitySerializer(serializers.ModelSerializer):
     )
 
     tags = NestedTagSerializer(
-        required=False,
-        allow_null=True,
+        read_only=True,
         many=True,
     )
     tag_ids = serializers.PrimaryKeyRelatedField(
         many=True,
         required=False,
+        allow_null=True,
         source='tags',
         queryset=Tag.objects.all(),
     )
@@ -367,13 +367,13 @@ class ProductSerializer(serializers.ModelSerializer):
     )
 
     tags = NestedTagSerializer(
-        required=False,
-        allow_null=True,
+        read_only=True,
         many=True,
     )
     tag_ids = serializers.PrimaryKeyRelatedField(
         many=True,
         required=False,
+        allow_null=True,
         source='tags',
         queryset=Tag.objects.all(),
     )
@@ -548,13 +548,13 @@ class ItemSerializer(serializers.ModelSerializer):
     )
 
     tags = NestedTagSerializer(
-        required=False,
-        allow_null=True,
+        read_only=True,
         many=True,
     )
     tag_ids = serializers.PrimaryKeyRelatedField(
         many=True,
         required=False,
+        allow_null=True,
         source='tags',
         queryset=Tag.objects.all(),
     )

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -7,16 +7,6 @@ from .models import (
 )
 
 
-class ProductInventoryIdSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ProductInventoryId
-        fields = [
-            'id',
-            'value',
-            'schema',
-        ]
-
-
 class InventoryIdSchemaSerializer(serializers.ModelSerializer):
     class Meta:
         model = InventoryIdSchema
@@ -24,6 +14,29 @@ class InventoryIdSchemaSerializer(serializers.ModelSerializer):
             'id',
             'name',
             'note',
+        ]
+
+
+class NestedProductInventoryIdSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='productinventoryid-detail')
+
+    schema = InventoryIdSchemaSerializer(
+        read_only=True,
+    )
+    schema_id = serializers.PrimaryKeyRelatedField(
+        source='schema',
+        queryset=InventoryIdSchema.objects.all(),
+    )
+
+    class Meta:
+        model = ProductInventoryId
+        fields = [
+            '_url',
+            'id',
+            'value',
+            'schema',
+            'schema_id',
+            'product_id',
         ]
 
 
@@ -236,17 +249,6 @@ class EntitySerializer(serializers.ModelSerializer):
         ]
 
 
-class ProductInventoryIdSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ProductInventoryId
-        fields = [
-            'id',
-            'value',
-            'schema',
-            'product',
-        ]
-
-
 class ItemInventoryIdSerializer(serializers.ModelSerializer):
     class Meta:
         model = ItemInventoryId
@@ -274,7 +276,7 @@ class NestedProductSerializer(serializers.ModelSerializer):
 class ProductSerializer(serializers.ModelSerializer):
     _url = serializers.HyperlinkedIdentityField(view_name='product-detail')
 
-    productinventoryid_set = ItemInventoryIdSerializer(
+    productinventoryid_set = NestedProductInventoryIdSerializer(
         read_only=True,
         many=True,
     )
@@ -285,7 +287,7 @@ class ProductSerializer(serializers.ModelSerializer):
         queryset=ProductInventoryId.objects.all(),
     )
 
-    productdata_set = ItemDataSerializer(
+    productdata_set = ProductDataSerializer(
         read_only=True,
         many=True,
     )
@@ -320,6 +322,38 @@ class ProductSerializer(serializers.ModelSerializer):
             'productdata_id_set',
             'tags',
             'tag_ids',
+        ]
+
+
+class ProductInventoryIdSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='productinventoryid-detail')
+
+    schema = InventoryIdSchemaSerializer(
+        read_only=True,
+    )
+    schema_id = serializers.PrimaryKeyRelatedField(
+        source='schema',
+        queryset=InventoryIdSchema.objects.all(),
+    )
+
+    product = NestedProductSerializer(
+        read_only=True,
+    )
+    product_id = serializers.PrimaryKeyRelatedField(
+        source='product',
+        queryset=Product.objects.all(),
+    )
+
+    class Meta:
+        model = ProductInventoryId
+        fields = [
+            '_url',
+            'id',
+            'value',
+            'schema',
+            'schema_id',
+            'product',
+            'product_id',
         ]
 
 

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -212,6 +212,7 @@ class ItemSerializer(serializers.ModelSerializer):
     )
     belongs_to_id = serializers.PrimaryKeyRelatedField(
         required=False,
+        allow_null=True,
         source='belongs_to',
         queryset=Entity.objects.all(),
     )
@@ -221,6 +222,7 @@ class ItemSerializer(serializers.ModelSerializer):
     )
     actual_location_id = serializers.PrimaryKeyRelatedField(
         required=False,
+        allow_null=True,
         source='actual_location',
         queryset=Location.objects.all(),
     )
@@ -230,6 +232,7 @@ class ItemSerializer(serializers.ModelSerializer):
     )
     target_location_id = serializers.PrimaryKeyRelatedField(
         required=False,
+        allow_null=True,
         source='target_location',
         queryset=Location.objects.all(),
     )

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -158,9 +158,12 @@ class NestedProductDataSerializer(serializers.ModelSerializer):
 
 
 class InventoryIdSchemaSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='inventoryidschema-detail')
+
     class Meta:
         model = InventoryIdSchema
         fields = [
+            '_url',
             'id',
             'name',
             'note',

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -329,14 +329,26 @@ class OverlayItemSerializer(serializers.ModelSerializer):
         ]
 
 
-class ItemInventoryIdSerializer(serializers.ModelSerializer):
+class NestedItemInventoryIdSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='iteminventoryid-detail')
+
+    schema = InventoryIdSchemaSerializer(
+        read_only=True,
+    )
+    schema_id = serializers.PrimaryKeyRelatedField(
+        source='schema',
+        queryset=InventoryIdSchema.objects.all(),
+    )
+
     class Meta:
         model = ItemInventoryId
         fields = [
+            '_url',
             'id',
             'value',
             'schema',
-            'item',
+            'schema_id',
+            'item_id',
         ]
 
 
@@ -551,7 +563,7 @@ class ItemSerializer(serializers.ModelSerializer):
         queryset=Item.objects.all(),
     )
 
-    iteminventoryid_set = ItemInventoryIdSerializer(
+    iteminventoryid_set = NestedItemInventoryIdSerializer(
         read_only=True,
         many=True,
     )
@@ -611,6 +623,38 @@ class ItemSerializer(serializers.ModelSerializer):
             'itemdata_id_set',
             'tags',
             'tag_ids',
+        ]
+
+
+class ItemInventoryIdSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='iteminventoryid-detail')
+
+    schema = InventoryIdSchemaSerializer(
+        read_only=True,
+    )
+    schema_id = serializers.PrimaryKeyRelatedField(
+        source='schema',
+        queryset=InventoryIdSchema.objects.all(),
+    )
+
+    item = NestedItemSerializer(
+        read_only=True,
+    )
+    item_id = serializers.PrimaryKeyRelatedField(
+        source='item',
+        queryset=Item.objects.all(),
+    )
+
+    class Meta:
+        model = ItemInventoryId
+        fields = [
+            '_url',
+            'id',
+            'value',
+            'schema',
+            'schema_id',
+            'item',
+            'item_id',
         ]
 
 

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -144,7 +144,6 @@ class NestedProductDataSerializer(serializers.ModelSerializer):
         queryset=DataType.objects.all(),
     )
 
-
     class Meta:
         model = ProductData
         fields = [
@@ -204,7 +203,6 @@ class NestedItemDataSerializer(serializers.ModelSerializer):
         queryset=DataType.objects.all(),
     )
 
-
     class Meta:
         model = ItemData
         fields = [
@@ -234,7 +232,6 @@ class NestedLocationSerializer(serializers.ModelSerializer):
 class LocationSerializer(serializers.ModelSerializer):
     _url = serializers.HyperlinkedIdentityField(view_name='location-detail')
 
-
     in_location = NestedLocationSerializer(
         read_only=True,
     )
@@ -255,7 +252,6 @@ class LocationSerializer(serializers.ModelSerializer):
         source='locationdata_set',
         queryset=LocationData.objects.all(),
     )
-
 
     class Meta:
         model = Location
@@ -289,7 +285,6 @@ class LocationDataSerializer(serializers.ModelSerializer):
         source='location',
         queryset=Location.objects.all(),
     )
-
 
     class Meta:
         model = LocationData

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -39,19 +39,6 @@ class NestedProductInventoryIdSerializer(serializers.ModelSerializer):
             'product_id',
         ]
 
-
-class LocationSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Location
-        fields = [
-            'id',
-            'name',
-            'note',
-            'in_location',
-            'locationdata_set',
-        ]
-
-
 class TagSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tag
@@ -497,18 +484,4 @@ class ItemSerializer(serializers.ModelSerializer):
             'itemdata_id_set',
             'tags',
             'tag_ids',
-        ]
-
-
-class ItemDataSerializer(serializers.ModelSerializer):
-    type = DataTypeSerializer()
-    item = ItemSerializer()
-
-    class Meta:
-        model = ItemData
-        fields = [
-            'id',
-            'value',
-            'type',
-            'item',
         ]

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -176,16 +176,69 @@ class ItemInventoryIdSerializer(serializers.ModelSerializer):
             'item',
         ]
 
-class ProductSerializer(serializers.ModelSerializer):
+
+class NestedProductSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='product-detail')
+
     class Meta:
         model = Product
         fields = [
+            '_url',
             'id',
             'name',
             'note',
-            'tags',
+        ]
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='product-detail')
+
+    productinventoryid_set = ItemInventoryIdSerializer(
+        read_only=True,
+        many=True,
+    )
+    productinventoryid_id_set = serializers.PrimaryKeyRelatedField(
+        many=True,
+        required=False,
+        source='productinventoryid_set',
+        queryset=ProductInventoryId.objects.all(),
+    )
+
+    productdata_set = ItemDataSerializer(
+        read_only=True,
+        many=True,
+    )
+    productdata_id_set = serializers.PrimaryKeyRelatedField(
+        many=True,
+        required=False,
+        source='productdata_set',
+        queryset=ProductData.objects.all(),
+    )
+
+    tags = TagSerializer(
+        read_only=True,
+        many=True,
+    )
+    tag_ids = serializers.PrimaryKeyRelatedField(
+        many=True,
+        required=False,
+        source='tags',
+        queryset=Tag.objects.all(),
+    )
+
+    class Meta:
+        model = Product
+        fields = [
+            '_url',
+            'id',
+            'name',
+            'note',
             'productinventoryid_set',
+            'productinventoryid_id_set',
             'productdata_set',
+            'productdata_id_set',
+            'tags',
+            'tag_ids',
         ]
 
 
@@ -242,7 +295,7 @@ class ItemSerializer(serializers.ModelSerializer):
         queryset=Location.objects.all(),
     )
 
-    product = ProductSerializer(
+    product = NestedProductSerializer(
         read_only=True,
     )
     product_id = serializers.PrimaryKeyRelatedField(

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -189,6 +189,23 @@ class ProductSerializer(serializers.ModelSerializer):
         ]
 
 
+class NestedItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Item
+        fields = [
+            'id',
+            'name',
+            'note',
+            'amount',
+            'belongs_to_id',
+            'actual_location_id',
+            'target_location_id',
+            'product_id',
+            'target_item_id',
+            'actual_item_id',
+        ]
+
+
 class ItemSerializer(serializers.ModelSerializer):
     belongs_to = EntitySerializer(
         read_only=True,
@@ -225,7 +242,9 @@ class ItemSerializer(serializers.ModelSerializer):
         queryset=Product.objects.all(),
     )
 
-    #target_item = ItemSerializer()
+    target_item = NestedItemSerializer(
+        read_only=True,
+    )
     target_item_id = serializers.PrimaryKeyRelatedField(
         required=False,
         allow_null=True,
@@ -233,7 +252,9 @@ class ItemSerializer(serializers.ModelSerializer):
         queryset=Item.objects.all(),
     )
 
-    #actual_item = ItemSerializer()
+    actual_item = NestedItemSerializer(
+        read_only=True,
+    )
     actual_item_id = serializers.PrimaryKeyRelatedField(
         required=False,
         allow_null=True,

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -193,14 +193,27 @@ class NestedProductInventoryIdSerializer(serializers.ModelSerializer):
         ]
 
 
-class ItemDataSerializer(serializers.ModelSerializer):
+class NestedItemDataSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='itemdata-detail')
+
+    type = DataTypeSerializer(
+        read_only=True,
+    )
+    type_id = serializers.PrimaryKeyRelatedField(
+        source='type',
+        queryset=DataType.objects.all(),
+    )
+
+
     class Meta:
         model = ItemData
         fields = [
+            '_url',
             'id',
             'value',
             'type',
-            'item',
+            'type_id',
+            'item_id',
         ]
 
 
@@ -549,7 +562,7 @@ class ItemSerializer(serializers.ModelSerializer):
         queryset=ItemInventoryId.objects.all(),
     )
 
-    itemdata_set = ItemDataSerializer(
+    itemdata_set = NestedItemDataSerializer(
         read_only=True,
         many=True,
     )
@@ -598,4 +611,36 @@ class ItemSerializer(serializers.ModelSerializer):
             'itemdata_id_set',
             'tags',
             'tag_ids',
+        ]
+
+
+class ItemDataSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='itemdata-detail')
+
+    type = DataTypeSerializer(
+        read_only=True,
+    )
+    type_id = serializers.PrimaryKeyRelatedField(
+        source='type',
+        queryset=DataType.objects.all(),
+    )
+
+    item = NestedItemSerializer(
+        read_only=True,
+    )
+    item_id = serializers.PrimaryKeyRelatedField(
+        source='item',
+        queryset=Item.objects.all(),
+    )
+
+    class Meta:
+        model = ItemData
+        fields = [
+            '_url',
+            'id',
+            'value',
+            'type',
+            'type_id',
+            'item',
+            'item_id',
         ]

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -246,12 +246,6 @@ class LocationSerializer(serializers.ModelSerializer):
         read_only=True,
         many=True,
     )
-    locationdata_id_set = serializers.PrimaryKeyRelatedField(
-        many=True,
-        required=False,
-        source='locationdata_set',
-        queryset=LocationData.objects.all(),
-    )
 
     class Meta:
         model = Location
@@ -263,7 +257,6 @@ class LocationSerializer(serializers.ModelSerializer):
             'in_location',
             'in_location_id',
             'locationdata_set',
-            'locationdata_id_set',
         ]
 
 
@@ -367,22 +360,10 @@ class ProductSerializer(serializers.ModelSerializer):
         read_only=True,
         many=True,
     )
-    productinventoryid_id_set = serializers.PrimaryKeyRelatedField(
-        many=True,
-        required=False,
-        source='productinventoryid_set',
-        queryset=ProductInventoryId.objects.all(),
-    )
 
     productdata_set = NestedProductDataSerializer(
         read_only=True,
         many=True,
-    )
-    productdata_id_set = serializers.PrimaryKeyRelatedField(
-        many=True,
-        required=False,
-        source='productdata_set',
-        queryset=ProductData.objects.all(),
     )
 
     tags = NestedTagSerializer(
@@ -405,9 +386,7 @@ class ProductSerializer(serializers.ModelSerializer):
             'name',
             'note',
             'productinventoryid_set',
-            'productinventoryid_id_set',
             'productdata_set',
-            'productdata_id_set',
             'tags',
             'tag_ids',
         ]
@@ -562,22 +541,10 @@ class ItemSerializer(serializers.ModelSerializer):
         read_only=True,
         many=True,
     )
-    iteminventoryid_id_set = serializers.PrimaryKeyRelatedField(
-        many=True,
-        required=False,
-        source='iteminventoryid_set',
-        queryset=ItemInventoryId.objects.all(),
-    )
 
     itemdata_set = NestedItemDataSerializer(
         read_only=True,
         many=True,
-    )
-    itemdata_id_set = serializers.PrimaryKeyRelatedField(
-        many=True,
-        required=False,
-        source='itemdata_set',
-        queryset=ItemData.objects.all(),
     )
 
     tags = NestedTagSerializer(
@@ -613,9 +580,7 @@ class ItemSerializer(serializers.ModelSerializer):
             'actual_item',
             'actual_item_id',
             'iteminventoryid_set',
-            'iteminventoryid_id_set',
             'itemdata_set',
-            'itemdata_id_set',
             'tags',
             'tag_ids',
         ]

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -143,15 +143,55 @@ class OverlayItemSerializer(serializers.ModelSerializer):
         ]
 
 
-class EntitySerializer(serializers.ModelSerializer):
+class NestedEntitySerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='entity-detail')
+
     class Meta:
         model = Entity
         fields = [
+            '_url',
+            'id',
+            'name',
+            'note',
+            'part_of_id',
+        ]
+
+
+class EntitySerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='entity-detail')
+
+    part_of = NestedEntitySerializer(
+        read_only=True,
+    )
+    part_of_id = serializers.PrimaryKeyRelatedField(
+        required=False,
+        allow_null=True,
+        source='part_of',
+        queryset=Entity.objects.all(),
+    )
+
+    tags = TagSerializer(
+        read_only=True,
+        many=True,
+    )
+    tag_ids = serializers.PrimaryKeyRelatedField(
+        many=True,
+        required=False,
+        source='tags',
+        queryset=Tag.objects.all(),
+    )
+
+    class Meta:
+        model = Entity
+        fields = [
+            '_url',
             'id',
             'name',
             'note',
             'part_of',
+            'part_of_id',
             'tags',
+            'tag_ids',
         ]
 
 
@@ -265,7 +305,7 @@ class NestedItemSerializer(serializers.ModelSerializer):
 class ItemSerializer(serializers.ModelSerializer):
     _url = serializers.HyperlinkedIdentityField(view_name='item-detail')
 
-    belongs_to = EntitySerializer(
+    belongs_to = NestedEntitySerializer(
         read_only=True,
     )
     belongs_to_id = serializers.PrimaryKeyRelatedField(

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -92,18 +92,59 @@ class LocationDataSerializer(serializers.ModelSerializer):
         ]
 
 
-class LocationSerializer(serializers.ModelSerializer):
-    locationdata_set = LocationDataSerializer(many=True, required=False, read_only=True)
-    in_location = LocationSerializer()
+class NestedLocationSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='location-detail')
 
     class Meta:
         model = Location
         fields = [
+            '_url',
+            'id',
+            'name',
+            'note',
+            'in_location_id',
+        ]
+
+
+class LocationSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='location-detail')
+
+
+    in_location = NestedLocationSerializer(
+        read_only=True,
+    )
+    in_location_id = serializers.PrimaryKeyRelatedField(
+        required=False,
+        allow_null=True,
+        source='in_location',
+        queryset=Location.objects.all(),
+    )
+
+    locationdata_set = LocationDataSerializer(
+        read_only=True,
+        many=True,
+    )
+    locationdata_id_set = serializers.PrimaryKeyRelatedField(
+        many=True,
+        required=False,
+        source='locationdata_set',
+        queryset=LocationData.objects.all(),
+    )
+
+
+    locationdata_set = LocationDataSerializer(many=True, required=False, read_only=True)
+
+    class Meta:
+        model = Location
+        fields = [
+            '_url',
             'id',
             'name',
             'note',
             'in_location',
-            'locationdata_set'
+            'in_location_id',
+            'locationdata_set',
+            'locationdata_id_set',
         ]
 
 
@@ -315,7 +356,7 @@ class ItemSerializer(serializers.ModelSerializer):
         queryset=Entity.objects.all(),
     )
 
-    actual_location = LocationSerializer(
+    actual_location = NestedLocationSerializer(
         read_only=True,
     )
     actual_location_id = serializers.PrimaryKeyRelatedField(
@@ -325,7 +366,7 @@ class ItemSerializer(serializers.ModelSerializer):
         queryset=Location.objects.all(),
     )
 
-    target_location = LocationSerializer(
+    target_location = NestedLocationSerializer(
         read_only=True,
     )
     target_location_id = serializers.PrimaryKeyRelatedField(

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -190,9 +190,12 @@ class ProductSerializer(serializers.ModelSerializer):
 
 
 class NestedItemSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='item-detail')
+
     class Meta:
         model = Item
         fields = [
+            '_url',
             'id',
             'name',
             'note',
@@ -207,6 +210,8 @@ class NestedItemSerializer(serializers.ModelSerializer):
 
 
 class ItemSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='item-detail')
+
     belongs_to = EntitySerializer(
         read_only=True,
     )
@@ -301,6 +306,7 @@ class ItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = Item
         fields = [
+            '_url',
             'id',
             'name',
             'note',

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -7,7 +7,7 @@ from .models import (
 )
 
 
-class CommonBasicInventoryIdSerializer(serializers.ModelSerializer):
+class ProductInventoryIdSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductInventoryId
         fields = [
@@ -27,7 +27,7 @@ class InventoryIdSchemaSerializer(serializers.ModelSerializer):
         ]
 
 
-class BasicLocationSerializer(serializers.ModelSerializer):
+class LocationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Location
         fields = [
@@ -39,44 +39,13 @@ class BasicLocationSerializer(serializers.ModelSerializer):
         ]
 
 
-class BasicTagSerializer(serializers.ModelSerializer):
+class TagSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tag
         fields = [
             'id',
             'name',
             'parent'
-        ]
-
-    def validate(self, data):
-        """
-        When the object is updated, self.instance still is the original
-        instance. If we validate on that, we could use self as a parent
-        but not change it afterwards. Thus, as far as I know, we cant
-        use validators on the models.
-        """
-
-        if ('parent' in data and
-            data['parent'] is not None and
-            self.instance is not None and
-                data['parent'].pk == self.instance.pk):
-
-            raise serializers.ValidationError(
-                {'parent': "Must not be self"},
-            )
-
-        return data
-
-
-class TagSerializer(BasicTagSerializer):
-    parent = BasicTagSerializer(required=False)
-
-    class Meta:
-        model = Tag
-        fields = [
-            'id',
-            'name',
-            'parent',
         ]
 
 
@@ -90,7 +59,7 @@ class DataTypeSerializer(serializers.ModelSerializer):
         ]
 
 
-class BasicItemDataSerializer(serializers.ModelSerializer):
+class ItemDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = ItemData
         fields = [
@@ -101,7 +70,7 @@ class BasicItemDataSerializer(serializers.ModelSerializer):
         ]
 
 
-class BasicProductDataSerializer(serializers.ModelSerializer):
+class ProductDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductData
         fields = [
@@ -112,7 +81,7 @@ class BasicProductDataSerializer(serializers.ModelSerializer):
         ]
 
 
-class WritableLocationDataSerializer(serializers.ModelSerializer):
+class LocationDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = LocationData
         fields = [
@@ -123,13 +92,9 @@ class WritableLocationDataSerializer(serializers.ModelSerializer):
         ]
 
 
-class BasicLocationDataSerializer(WritableLocationDataSerializer):
-    type = DataTypeSerializer()
-
-
 class LocationSerializer(serializers.ModelSerializer):
-    locationdata_set = BasicLocationDataSerializer(many=True, required=False, read_only=True)
-    in_location = BasicLocationSerializer()
+    locationdata_set = LocationDataSerializer(many=True, required=False, read_only=True)
+    in_location = LocationSerializer()
 
     class Meta:
         model = Location
@@ -141,26 +106,8 @@ class LocationSerializer(serializers.ModelSerializer):
             'locationdata_set'
         ]
 
-    def validate(self, data):
-        """
-        See TagSerializer.validate().
-        """
-
-        if (data['in_location'] is not None and
-            self.instance is not None and
-                data['in_location'].pk == self.instance.pk):
-
-            raise serializers.ValidationError(
-                {'in_location': "Must not be self"},
-            )
-
-        return data
-
 
 class LocationDataSerializer(serializers.ModelSerializer):
-    type = DataTypeSerializer()
-    location = BasicLocationSerializer()
-
     class Meta:
         model = LocationData
         fields = [
@@ -171,7 +118,7 @@ class LocationDataSerializer(serializers.ModelSerializer):
         ]
 
 
-class BasicOverlaySerializer(serializers.ModelSerializer):
+class OverlaySerializer(serializers.ModelSerializer):
     class Meta:
         model = Overlay
         fields = [
@@ -183,23 +130,8 @@ class BasicOverlaySerializer(serializers.ModelSerializer):
             'overlayitem_set',
         ]
 
-    def validate(self, data):
-        """
-        See TagSerializer.validate().
-        """
 
-        if (data['parent'] is not None and
-            self.instance is not None and
-                data['parent'].pk == self.instance.pk):
-
-            raise serializers.ValidationError(
-                {'parent': "Must not be self"},
-            )
-
-        return data
-
-
-class WritableOverlayItemSerializer(serializers.ModelSerializer):
+class OverlayItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = OverlayItem
         fields = [
@@ -211,7 +143,7 @@ class WritableOverlayItemSerializer(serializers.ModelSerializer):
         ]
 
 
-class BasicEntitySerializer(serializers.ModelSerializer):
+class EntitySerializer(serializers.ModelSerializer):
     class Meta:
         model = Entity
         fields = [
@@ -222,28 +154,8 @@ class BasicEntitySerializer(serializers.ModelSerializer):
             'tags',
         ]
 
-    def validate(self, data):
-        """
-        See TagSerializer.validate().
-        """
 
-        if (data['part_of'] is not None and
-            self.instance is not None and
-                data['part_of'].pk == self.instance.pk):
-
-            raise serializers.ValidationError(
-                {'part_of': "Must not be self"},
-            )
-
-        return data
-
-
-class EntitySerializer(BasicEntitySerializer):
-    tags = TagSerializer(many=True, required=False)
-    part_of = BasicEntitySerializer()
-
-
-class WritableProductInventoryIdSerializer(serializers.ModelSerializer):
+class ProductInventoryIdSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductInventoryId
         fields = [
@@ -254,11 +166,7 @@ class WritableProductInventoryIdSerializer(serializers.ModelSerializer):
         ]
 
 
-class BasicProductInventoryIdSerializer(WritableProductInventoryIdSerializer):
-    schema = InventoryIdSchemaSerializer()
-
-
-class WritableItemInventoryIdSerializer(serializers.ModelSerializer):
+class ItemInventoryIdSerializer(serializers.ModelSerializer):
     class Meta:
         model = ItemInventoryId
         fields = [
@@ -268,12 +176,7 @@ class WritableItemInventoryIdSerializer(serializers.ModelSerializer):
             'item',
         ]
 
-
-class BasicItemInventoryIdSerializer(WritableItemInventoryIdSerializer):
-    schema = InventoryIdSchemaSerializer()
-
-
-class BasicProductSerializer(serializers.ModelSerializer):
+class ProductSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
         fields = [
@@ -286,32 +189,7 @@ class BasicProductSerializer(serializers.ModelSerializer):
         ]
 
 
-class ProductDataSerializer(BasicProductDataSerializer):
-    type = DataTypeSerializer()
-    product = BasicProductSerializer()
-
-
-class ProductInventoryIdSerializer(BasicProductInventoryIdSerializer):
-    product = BasicProductSerializer()
-
-
-class ProductSerializer(serializers.ModelSerializer):
-    tags = TagSerializer(many=True, required=False)
-
-    productdata_set = BasicProductDataSerializer(
-        many=True,
-        required=False
-    )
-    productinventoryid_set = BasicProductInventoryIdSerializer(
-        many=True,
-        required=False
-    )
-
-    class Meta(BasicProductSerializer.Meta):
-        pass
-
-
-class BasicItemSerializer(serializers.ModelSerializer):
+class ItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = Item
         fields = [
@@ -333,7 +211,7 @@ class BasicItemSerializer(serializers.ModelSerializer):
 
 class ItemDataSerializer(serializers.ModelSerializer):
     type = DataTypeSerializer()
-    item = BasicItemSerializer()
+    item = ItemSerializer()
 
     class Meta:
         model = ItemData
@@ -343,43 +221,3 @@ class ItemDataSerializer(serializers.ModelSerializer):
             'type',
             'item',
         ]
-
-
-class ItemSerializer(serializers.ModelSerializer):
-    tags = TagSerializer(many=True, required=False)
-    belongs_to = EntitySerializer(required=False)
-    product = ProductSerializer()
-    target_location = LocationSerializer(required=False)
-    actual_location = LocationSerializer(required=False)
-
-    itemdata_set = BasicItemDataSerializer(
-        many=True,
-        required=False,
-    )
-
-    iteminventoryid_set = BasicItemInventoryIdSerializer(
-        many=True,
-        required=False
-    )
-
-    class Meta(BasicItemSerializer.Meta):
-        pass
-
-
-class ItemInventoryIdSerializer(BasicItemInventoryIdSerializer):
-    item = BasicItemSerializer
-
-
-class BasicOverlayItemSerializer(WritableOverlayItemSerializer):
-    item = BasicItemSerializer()
-    target_item = BasicItemSerializer()
-    target_location = LocationSerializer()
-
-
-class OverlaySerializer(BasicOverlaySerializer):
-    parent = BasicOverlaySerializer()
-    overlayitem_set = BasicOverlayItemSerializer(many=True)
-
-
-class OverlayItemSerializer(BasicOverlayItemSerializer):
-    overlay = BasicOverlaySerializer()

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -110,6 +110,29 @@ class EntitySerializer(serializers.ModelSerializer):
         ]
 
 
+class NestedLocationDataSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='locationdata-detail')
+
+    type = DataTypeSerializer(
+        read_only=True,
+    )
+    type_id = serializers.PrimaryKeyRelatedField(
+        source='type',
+        queryset=DataType.objects.all(),
+    )
+
+    class Meta:
+        model = LocationData
+        fields = [
+            '_url',
+            'id',
+            'value',
+            'type',
+            'type_id',
+            'location_id',
+        ]
+
+
 class InventoryIdSchemaSerializer(serializers.ModelSerializer):
     class Meta:
         model = InventoryIdSchema
@@ -165,17 +188,6 @@ class ProductDataSerializer(serializers.ModelSerializer):
         ]
 
 
-class LocationDataSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = LocationData
-        fields = [
-            'id',
-            'value',
-            'type',
-            'location',
-        ]
-
-
 class NestedLocationSerializer(serializers.ModelSerializer):
     _url = serializers.HyperlinkedIdentityField(view_name='location-detail')
 
@@ -204,7 +216,7 @@ class LocationSerializer(serializers.ModelSerializer):
         queryset=Location.objects.all(),
     )
 
-    locationdata_set = LocationDataSerializer(
+    locationdata_set = NestedLocationDataSerializer(
         read_only=True,
         many=True,
     )
@@ -215,8 +227,6 @@ class LocationSerializer(serializers.ModelSerializer):
         queryset=LocationData.objects.all(),
     )
 
-
-    locationdata_set = LocationDataSerializer(many=True, required=False, read_only=True)
 
     class Meta:
         model = Location
@@ -233,13 +243,35 @@ class LocationSerializer(serializers.ModelSerializer):
 
 
 class LocationDataSerializer(serializers.ModelSerializer):
+    _url = serializers.HyperlinkedIdentityField(view_name='locationdata-detail')
+
+    type = DataTypeSerializer(
+        read_only=True,
+    )
+    type_id = serializers.PrimaryKeyRelatedField(
+        source='type',
+        queryset=DataType.objects.all(),
+    )
+
+    location = NestedLocationSerializer(
+        read_only=True,
+    )
+    location_id = serializers.PrimaryKeyRelatedField(
+        source='location',
+        queryset=Location.objects.all(),
+    )
+
+
     class Meta:
         model = LocationData
         fields = [
+            '_url',
             'id',
             'value',
             'type',
-            'location'
+            'type_id',
+            'location',
+            'location_id',
         ]
 
 

--- a/src/chaosinventory/base/serializers.py
+++ b/src/chaosinventory/base/serializers.py
@@ -194,7 +194,6 @@ class ItemSerializer(serializers.ModelSerializer):
         read_only=True,
     )
     belongs_to_id = serializers.PrimaryKeyRelatedField(
-        write_only=True,
         required=False,
         source='belongs_to',
         queryset=Entity.objects.all(),
@@ -204,7 +203,6 @@ class ItemSerializer(serializers.ModelSerializer):
         read_only=True,
     )
     actual_location_id = serializers.PrimaryKeyRelatedField(
-        write_only=True,
         required=False,
         source='actual_location',
         queryset=Location.objects.all(),
@@ -214,7 +212,6 @@ class ItemSerializer(serializers.ModelSerializer):
         read_only=True,
     )
     target_location_id = serializers.PrimaryKeyRelatedField(
-        write_only=True,
         required=False,
         source='target_location',
         queryset=Location.objects.all(),
@@ -224,14 +221,12 @@ class ItemSerializer(serializers.ModelSerializer):
         read_only=True,
     )
     product_id = serializers.PrimaryKeyRelatedField(
-        write_only=True,
         source='product',
         queryset=Product.objects.all(),
     )
 
     #target_item = ItemSerializer()
     target_item_id = serializers.PrimaryKeyRelatedField(
-        write_only=True,
         required=False,
         allow_null=True,
         source='target_item',
@@ -240,7 +235,6 @@ class ItemSerializer(serializers.ModelSerializer):
 
     #actual_item = ItemSerializer()
     actual_item_id = serializers.PrimaryKeyRelatedField(
-        write_only=True,
         required=False,
         allow_null=True,
         source='actual_item',
@@ -252,7 +246,6 @@ class ItemSerializer(serializers.ModelSerializer):
         many=True,
     )
     iteminventoryid_id_set = serializers.PrimaryKeyRelatedField(
-        write_only=True,
         many=True,
         required=False,
         source='iteminventoryid_set',
@@ -264,7 +257,6 @@ class ItemSerializer(serializers.ModelSerializer):
         many=True,
     )
     itemdata_id_set = serializers.PrimaryKeyRelatedField(
-        write_only=True,
         many=True,
         required=False,
         source='itemdata_set',
@@ -276,7 +268,6 @@ class ItemSerializer(serializers.ModelSerializer):
         many=True,
     )
     tag_ids = serializers.PrimaryKeyRelatedField(
-        write_only=True,
         many=True,
         required=False,
         source='tags',

--- a/src/chaosinventory/base/urls.py
+++ b/src/chaosinventory/base/urls.py
@@ -4,20 +4,26 @@ from rest_framework.routers import DefaultRouter
 from .views import api, index
 
 router = DefaultRouter()
-router.register(r'inventoryidschema', api.InventoryIdSchemaViewSet)
-router.register(r'tag', api.TagViewSet)
-router.register(r'datatype', api.DataTypeViewSet)
-router.register(r'locationdata', api.LocationDataViewSet)
+
+router.register(r'item', api.ItemViewSet)
 router.register(r'itemdata', api.ItemDataViewSet)
+router.register(r'iteminventoryid', api.ItemInventoryIdViewSet)
+
+router.register(r'product', api.ProductViewSet)
 router.register(r'productdata', api.ProductDataViewSet)
+router.register(r'productinventoryid', api.ProductInventoryIdViewSet)
+
+router.register(r'location', api.LocationViewSet)
+router.register(r'locationdata', api.LocationDataViewSet)
+
+router.register(r'entity', api.EntityViewSet)
+
 router.register(r'overlay', api.OverlayViewSet)
 router.register(r'overlayitem', api.OverlayItemViewSet)
-router.register(r'entity', api.EntityViewSet)
-router.register(r'location', api.LocationViewSet)
-router.register(r'productinventoryid', api.ProductInventoryIdViewSet)
-router.register(r'product', api.ProductViewSet)
-router.register(r'iteminventoryid', api.ItemInventoryIdViewSet)
-router.register(r'item', api.ItemViewSet)
+
+router.register(r'tag', api.TagViewSet)
+router.register(r'datatype', api.DataTypeViewSet)
+router.register(r'inventoryidschema', api.InventoryIdSchemaViewSet)
 
 urlpatterns = [
     path('', index),

--- a/src/chaosinventory/base/views/api.py
+++ b/src/chaosinventory/base/views/api.py
@@ -1,7 +1,5 @@
-from rest_framework import status, viewsets
+from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.request import Request
-from rest_framework.response import Response
 
 from ..models import (
     DataType, Entity, InventoryIdSchema, Item, ItemData, ItemInventoryId,

--- a/src/chaosinventory/base/views/api.py
+++ b/src/chaosinventory/base/views/api.py
@@ -9,72 +9,12 @@ from ..models import (
     ProductInventoryId, Tag,
 )
 from ..serializers import (
-    BasicEntitySerializer, BasicItemDataSerializer, BasicItemSerializer,
-    BasicLocationSerializer, BasicOverlaySerializer,
-    BasicProductDataSerializer, BasicProductSerializer, BasicTagSerializer,
     DataTypeSerializer, EntitySerializer, InventoryIdSchemaSerializer,
     ItemDataSerializer, ItemInventoryIdSerializer, ItemSerializer,
     LocationDataSerializer, LocationSerializer, OverlayItemSerializer,
     OverlaySerializer, ProductDataSerializer, ProductInventoryIdSerializer,
-    ProductSerializer, TagSerializer, WritableItemInventoryIdSerializer,
-    WritableLocationDataSerializer, WritableOverlayItemSerializer,
-    WritableProductInventoryIdSerializer,
+    ProductSerializer, TagSerializer,
 )
-
-
-class AbstractModelViewSet(viewsets.ModelViewSet):
-    """
-    A wrapper class we can reuse for our recursive serializers
-    """
-
-    writable_serializer_class = None
-
-    def create(self, request: Request, **kwargs):
-        """
-        Create a Model instance.
-        """
-        serializer = self.writable_serializer_class(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        headers = self.get_success_headers(serializer.data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
-
-    def update(self, request: Request, *args, **kwargs):
-        """
-        Update a Model instance.
-        """
-        partial = kwargs.pop('partial', False)
-        instance = self.get_object()
-        serializer = self.writable_serializer_class(instance, data=request.data, partial=partial)
-        serializer.is_valid(raise_exception=True)
-        self.perform_update(serializer)
-
-        if getattr(instance, '_prefetched_objects_cache', None):
-            # If 'prefetch_related' has been applied to a queryset, we need to
-            # forcibly invalidate the prefetch cache on the instance.
-            instance._prefetched_objects_cache = {}
-
-        return Response(serializer.data)
-
-    def get_writable_serializer(self, *args, **kwargs):
-        """
-        Return the class to use for the serializer. Basically copied from
-        `rest_framework.viewsets.ViewSetMixin`, thus the two-function structure.
-
-        In the end, it returns the serializer specified in self.writable_serializer_class.
-        """
-        writable_serializer_class = self.get_writable_serializer_class()
-        kwargs.setdefault('context', self.get_serializer_context())
-        return writable_serializer_class(*args, **kwargs)
-
-    def get_writable_serializer_class(self):
-        assert self.writable_serializer_class is not None, (
-            "'%s' should either include a `serializer_class` attribute, "
-            "or overwrite the `get_serializer_class()` method."
-            % self.__class__.__name__
-        )
-
-        return self.writable_serializer_class
 
 
 class InventoryIdSchemaViewSet(viewsets.ModelViewSet):
@@ -82,11 +22,10 @@ class InventoryIdSchemaViewSet(viewsets.ModelViewSet):
     serializer_class = InventoryIdSchemaSerializer
 
 
-class TagViewSet(AbstractModelViewSet):
+class TagViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = Tag.objects.all()
     serializer_class = TagSerializer
-    writable_serializer_class = BasicTagSerializer
 
 
 class DataTypeViewSet(viewsets.ModelViewSet):
@@ -95,72 +34,61 @@ class DataTypeViewSet(viewsets.ModelViewSet):
     serializer_class = DataTypeSerializer
 
 
-class LocationDataViewSet(AbstractModelViewSet):
+class LocationDataViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = LocationData.objects.all()
     serializer_class = LocationDataSerializer
-    writable_serializer_class = WritableLocationDataSerializer
 
 
-class ItemDataViewSet(AbstractModelViewSet):
+class ItemDataViewSet(viewsets.ModelViewSet):
     queryset = ItemData.objects.all()
     serializer_class = ItemDataSerializer
-    writable_serializer_class = BasicItemDataSerializer
 
 
-class ProductDataViewSet(AbstractModelViewSet):
+class ProductDataViewSet(viewsets.ModelViewSet):
     queryset = ProductData.objects.all()
     serializer_class = ProductDataSerializer
-    writable_serializer_class = BasicProductDataSerializer
 
 
-class LocationViewSet(AbstractModelViewSet):
+class LocationViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = Location.objects.all()
     serializer_class = LocationSerializer
-    writable_serializer_class = BasicLocationSerializer
 
 
-class OverlayViewSet(AbstractModelViewSet):
+class OverlayViewSet(viewsets.ModelViewSet):
     queryset = Overlay.objects.all()
     serializer_class = OverlaySerializer
-    writable_serializer_class = BasicOverlaySerializer
 
 
-class OverlayItemViewSet(AbstractModelViewSet):
+class OverlayItemViewSet(viewsets.ModelViewSet):
     queryset = OverlayItem.objects.all()
     serializer_class = OverlayItemSerializer
-    writable_serializer_class = WritableOverlayItemSerializer
 
 
-class EntityViewSet(AbstractModelViewSet):
+class EntityViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = Entity.objects.all()
     serializer_class = EntitySerializer
-    writable_serializer_class = BasicEntitySerializer
 
 
-class ProductInventoryIdViewSet(AbstractModelViewSet):
+class ProductInventoryIdViewSet(viewsets.ModelViewSet):
     queryset = ProductInventoryId.objects.all()
     serializer_class = ProductInventoryIdSerializer
-    writable_serializer_class = WritableProductInventoryIdSerializer
 
 
-class ItemInventoryIdViewSet(AbstractModelViewSet):
+class ItemInventoryIdViewSet(viewsets.ModelViewSet):
     queryset = ItemInventoryId.objects.all()
     serializer_class = ItemInventoryIdSerializer
-    writable_serializer_class = WritableItemInventoryIdSerializer
 
 
-class ProductViewSet(AbstractModelViewSet):
+class ProductViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
-    writable_serializer_class = BasicProductSerializer
 
 
-class ItemViewSet(AbstractModelViewSet):
+class ItemViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = Item.objects.all()
     serializer_class = ItemSerializer
-    writable_serializer_class = BasicItemSerializer


### PR DESCRIPTION
I refactored the API serializers. The previous one had a good intention -writing less code-, but in the end it is probably way more stable to just stick to the basics of the framework and do it how they intended it.

I removed the changing data type on writes and just added `_id` fields to the relations. This field is used in our models to actually store the id of the referenced object. I used the relation name for the nested object representation. This field is read-only.

To represent nested objects and avoid rendering infinitely deep, I added an additional class to each serializer which renders the object in nested state. This outputs the `_id` fields and ignores some nested relation representations.

I appreciate testing from you. You can use the API just from the API exporer, but may need to comment out `permission_classes` in the API view because authentication in the explorer is kinda broken yet.