### PR TITLE
Enabling session authentication on API

### DIFF
--- a/src/chaosinventory/settings.py
+++ b/src/chaosinventory/settings.py
@@ -180,6 +180,7 @@ EMAIL_USE_SSL = config.getboolean('email', 'ssl', fallback=False)
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
         'chaosinventory.authentication.authentication.TokenAuthentication',
-    ]
+    ],
 }


### PR DESCRIPTION
To make exploring the API more easy  enabled session authentication for it. So you can just log in to the admin and then access the API too.