### PR TITLE
Add simple welcome page

### DIFF
--- a/src/chaosinventory/base/templates/base/index.html
+++ b/src/chaosinventory/base/templates/base/index.html
@@ -1,5 +1,13 @@
 {% extends 'base/base.html' %}
 
 {% block content %}
-<h1>Hello World</h1>
+<h1>Chaosinventory</h1>
+<p>Welcome to the Chaosinventory Backend.<br>
+This project does not have a frontend yet, but feel free to build your own using the API :)</p>
+<ul>
+  <li><a href="/admin/">Admin</a></li>
+  <li><a href="/api/">API</a></li>
+  <li><a href="https://chaosinventory.readthedocs.io/projects/core/" target="_blank">Docs</a></li>
+  <li><a href="https://github.com/chaosinventory/chaosinventory" target="_blank">GitHub</a></li>
+</ul>
 {% endblock content %}


### PR DESCRIPTION
Currently the main page of chaosinventory just shows a hello world. This is quite useless, so I added links and some explanation.